### PR TITLE
Improved properties handling for context

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,23 +58,23 @@ The context accepts several properties. Properties can be set as follows at Cont
 
 ```java
 Properties properties = new Properties();
-properties.setProperty(Constants.ADDR_LIST_KEY, "10.10.10.255");
+properties.setProperty(Context.Configuration.EPICS_CA_ADDR_LIST.toString(), "10.10.10.255");
 new Context(properties);
 ```
 
-The available properties are:
+All available properties are available in the Configuration enumeration inside the Context class. The available properties are:
 
 | Property | Desciption |
 |----|----|
-|Constants.ADDR_LIST_KEY||
-|Constants.AUTO_ADDR_LIST_KEY||
-|Constants.BEACON_PERIOD_KEY||
-|Constants.SERVER_PORT_KEY||
-|Constants.MAX_ARRAY_BYTES_KEY||
-|Constants.REPEATER_PORT_KEY||
-|Constants.CONN_TMO_KEY||
+|EPICS_CA_ADDR_LIST||
+|EPICS_CA_AUTO_ADDR_LIST||
+|EPICS_CA_CONN_TMO||
+|EPICS_CA_BEACON_PERIOD||
+|EPICS_CA_REPEATER_PORT||
+|EPICS_CA_SERVER_PORT||
+|EPICS_CA_MAX_ARRAY_BYTES||
 
-_Note:_ In contrast to other Channel Access libraries MAX_ARRAY_BYTES_KEY is set to unlimited by default. Therefore usually there is no reason to set this property.
+_Note:_ In contrast to other Channel Access libraries EPICS_CA_MAX_ARRAY_BYTES is set to unlimited by default. Therefore usually there is no reason to set this property.
 
 The context need to be closed at the end of the application via:
 

--- a/src/main/java/org/epics/ca/Constants.java
+++ b/src/main/java/org/epics/ca/Constants.java
@@ -1,19 +1,6 @@
 package org.epics.ca;
 
 public interface Constants {
-
-	/* -------- EPICS CA configuration keys -------- */
-	public static final String ADDR_LIST_KEY = "EPICS_CA_ADDR_LIST";
-	public static final String AUTO_ADDR_LIST_KEY = "EPICS_CA_AUTO_ADDR_LIST";
-	public static final String CONN_TMO_KEY = "EPICS_CA_CONN_TMO";
-	public static final String BEACON_PERIOD_KEY = "EPICS_CA_BEACON_PERIOD";
-	public static final String REPEATER_PORT_KEY = "EPICS_CA_REPEATER_PORT";
-	public static final String SERVER_PORT_KEY = "EPICS_CA_SERVER_PORT";
-	public static final String MAX_ARRAY_BYTES_KEY = "EPICS_CA_MAX_ARRAY_BYTES";
-	
-	public static enum Configuration { EPICS_CA_ADDR_LIST, EPICS_CA_AUTO_ADDR_LIST, EPICS_CA_CONN_TMO,
-		EPICS_CA_BEACON_PERIOD, EPICS_CA_REPEATER_PORT, EPICS_CA_SERVER_PORT,
-		EPICS_CA_MAX_ARRAY_BYTES };
 		
 	public static enum ChannelProperties { nativeType, nativeTypeCode, remoteAddress, nativeElementCount };
 	

--- a/src/main/java/org/epics/ca/Context.java
+++ b/src/main/java/org/epics/ca/Context.java
@@ -5,7 +5,11 @@ import java.util.Properties;
 import org.epics.ca.impl.ContextImpl;
 
 public class Context implements AutoCloseable {
-	
+
+	public enum Configuration { EPICS_CA_ADDR_LIST, EPICS_CA_AUTO_ADDR_LIST, EPICS_CA_CONN_TMO,
+		EPICS_CA_BEACON_PERIOD, EPICS_CA_REPEATER_PORT, EPICS_CA_SERVER_PORT,
+		EPICS_CA_MAX_ARRAY_BYTES };
+
 	private final ContextImpl delegate;
 	
 	public Context()

--- a/src/main/java/org/epics/ca/impl/ContextImpl.java
+++ b/src/main/java/org/epics/ca/impl/ContextImpl.java
@@ -23,6 +23,7 @@ import java.util.logging.Logger;
 
 import org.epics.ca.Channel;
 import org.epics.ca.Constants;
+import org.epics.ca.Context;
 import org.epics.ca.Version;
 import org.epics.ca.impl.reactor.Reactor;
 import org.epics.ca.impl.reactor.ReactorHandler;
@@ -296,30 +297,30 @@ public class ContextImpl implements AutoCloseable, Constants {
 		// dump version
 		logger.config(() -> "Java CA v" + Version.getVersionString());
 		
-		addressList = readStringProperty(properties, ADDR_LIST_KEY, addressList);
-		logger.config(() -> ADDR_LIST_KEY + ": " + addressList);
+		addressList = readStringProperty(properties, Context.Configuration.EPICS_CA_ADDR_LIST.toString(), addressList);
+		logger.config(() -> Context.Configuration.EPICS_CA_ADDR_LIST.toString() + ": " + addressList);
 		
-		autoAddressList = readBooleanProperty(properties, AUTO_ADDR_LIST_KEY, autoAddressList);
-		logger.config(() -> AUTO_ADDR_LIST_KEY + ": " + autoAddressList);
+		autoAddressList = readBooleanProperty(properties, Context.Configuration.EPICS_CA_AUTO_ADDR_LIST.toString(), autoAddressList);
+		logger.config(() -> Context.Configuration.EPICS_CA_AUTO_ADDR_LIST.toString() + ": " + autoAddressList);
 
-		connectionTimeout = readFloatProperty(properties, CONN_TMO_KEY, connectionTimeout);
+		connectionTimeout = readFloatProperty(properties, Context.Configuration.EPICS_CA_CONN_TMO.toString(), connectionTimeout);
 		connectionTimeout = Math.max(0.1f, connectionTimeout);
-		logger.config(() -> CONN_TMO_KEY + ": " + connectionTimeout);
+		logger.config(() -> Context.Configuration.EPICS_CA_CONN_TMO.toString() + ": " + connectionTimeout);
 
-		beaconPeriod = readFloatProperty(properties, BEACON_PERIOD_KEY, beaconPeriod);
+		beaconPeriod = readFloatProperty(properties, Context.Configuration.EPICS_CA_BEACON_PERIOD.toString(), beaconPeriod);
 		beaconPeriod = Math.max(0.1f, beaconPeriod);
-		logger.config(() -> BEACON_PERIOD_KEY + ": " + beaconPeriod);
+		logger.config(() -> Context.Configuration.EPICS_CA_BEACON_PERIOD.toString() + ": " + beaconPeriod);
 
-		repeaterPort = readIntegerProperty(properties, REPEATER_PORT_KEY, repeaterPort);
-		logger.config(() -> REPEATER_PORT_KEY + ": " + repeaterPort);
+		repeaterPort = readIntegerProperty(properties, Context.Configuration.EPICS_CA_REPEATER_PORT.toString(), repeaterPort);
+		logger.config(() -> Context.Configuration.EPICS_CA_REPEATER_PORT.toString() + ": " + repeaterPort);
 
-		serverPort = readIntegerProperty(properties, SERVER_PORT_KEY, serverPort);
-		logger.config(() -> SERVER_PORT_KEY + ": " + serverPort);
+		serverPort = readIntegerProperty(properties, Context.Configuration.EPICS_CA_SERVER_PORT.toString(), serverPort);
+		logger.config(() -> Context.Configuration.EPICS_CA_SERVER_PORT.toString() + ": " + serverPort);
 
-		maxArrayBytes = readIntegerProperty(properties, MAX_ARRAY_BYTES_KEY, maxArrayBytes);
+		maxArrayBytes = readIntegerProperty(properties, Context.Configuration.EPICS_CA_MAX_ARRAY_BYTES.toString(), maxArrayBytes);
 		if (maxArrayBytes > 0) 
 			maxArrayBytes = Math.max(1024,  maxArrayBytes);
-		logger.config(() -> MAX_ARRAY_BYTES_KEY + ": " + (maxArrayBytes > 0 ? maxArrayBytes : "(undefined)"));
+		logger.config(() -> Context.Configuration.EPICS_CA_MAX_ARRAY_BYTES.toString() + ": " + (maxArrayBytes > 0 ? maxArrayBytes : "(undefined)"));
 	}
 	
 	/**
@@ -722,9 +723,8 @@ public class ContextImpl implements AutoCloseable, Constants {
 		
 	}
 	
-	/**
+	/**g
 	 * Get, or create if necessary, transport of given server address.
-	 * @param serverAddress	required transport address
 	 * @param priority process priority.
 	 * @return transport for given address
 	 */


### PR DESCRIPTION
To make context configuration more simple and straight forward I removed the (duplicated) static Strings  within Constants and moved the Configuration enumeration into the Context class.
In terms of simplicity I am convinced that the enumeration belongs there, not in the artificial class Constants.
All use of the static strings are replaced with the enumeration.
The readme also got updated ...